### PR TITLE
fix the display of the intro warn image in local envs

### DIFF
--- a/app/assets/javascripts/views/embedded/EmbeddedContainerHtml.js
+++ b/app/assets/javascripts/views/embedded/EmbeddedContainerHtml.js
@@ -16,7 +16,7 @@ export const ContainerHtml = `
     <div id="ciapiChatComponents">
         <div id="ciapiSkinChatTranscript" role="log" tabindex="0">
             <div id="skipToBottom"><a id="skipToBottomLink" href="#" class="govuk-skip-link">Skip to bottom of conversation</a></div>
-            <p class="info"><img src="/engagement-platform-skin/assets/media/intro-warn.svg" alt="Introduction warning">You are currently chatting with a computer.</p>
+            <p class="info"><img src="/ask-hmrc/assets/media/intro-warn.svg" alt="Introduction warning">You are currently chatting with a computer.</p>
         </div>
         <div id="ciapiSkinFooter">
             <div>

--- a/app/assets/javascripts/views/popup/PopupContainerHtml.js
+++ b/app/assets/javascripts/views/popup/PopupContainerHtml.js
@@ -24,7 +24,7 @@ export const ContainerHtml = `
     <div id="ciapiChatComponents">
         <div id="ciapiSkinChatTranscript" role="log" tabindex="0">
             <div id="skipToBottom"><a id="skipToBottomLink" href="#skipToTopLink" class="govuk-skip-link">Skip to bottom of conversation</a></div>
-            <p class="info"><img src="/engagement-platform-skin/assets/media/intro-warn.svg" alt="Introduction warning">You are currently chatting with a computer.</p>
+            <p class="info"><img src="/ask-hmrc/assets/media/intro-warn.svg" alt="Introduction warning">You are currently chatting with a computer.</p>
         </div>
         <div id="ciapiSkinFooter">
             <div id="ciapiInput"><textarea


### PR DESCRIPTION
# DEP-IntroWarnFix

## Checklist PR Raiser
 - [x]  I've ensured code coverage has not decreased
 - [x]  I've dealt with any new compilation warnings
 - [x]  I've ensured the team's coding standards have been met (TBC)?
 - [ ]  If relevant, I've created corresponding app-config-XXX changes?
 - [ ]  If I've created new test data, I've ensured there is no real person's data (see https://confluence.tools.tax.service.gov.uk/display/CD/Test+Data+in+the+Open) 
 - [x]  I've considered the impact my changes have on the UI/Journey tests (please do not break them)
-  [ ]  If relevant, I've added links to associated PRs

## Checklist PR Reviewer
 - [x]  I've checked to ensure all relevant unit tests have been written
 - [x]  I've checked to ensure the team's coding standards have been met
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  If I merge I will ensure I use squash and merge