### PR TITLE
DEP-2525: Hide error div when automated msg gets generated

### DIFF
--- a/app/assets/javascripts/services/Transcript.js
+++ b/app/assets/javascripts/services/Transcript.js
@@ -22,9 +22,6 @@ export default class Transcript {
     }
 
     addOpenerScript(msg) {
-        if(document.getElementsByClassName("cui-technical-error")) {
-            document.getElementsByClassName("cui-technical-error").style.display = "none";
-        }
         this._appendMessage(msg, this.classes.Opener, this.automatedMsgPrefix, false);
     }
 
@@ -134,6 +131,11 @@ export default class Transcript {
     _appendMessage(msg, msg_class, msg_type, isCustomerMsg) {
 
         var id = "liveMsgId" + ( Math.random() * 100);
+
+        if(document && document.getElementById("errorDiv"))
+        {
+                document.getElementById("errorDiv").style.display = "none";
+        }
 
         if(isCustomerMsg == true){
                 var msgDiv = `<div class=${msg_class.Outer}><div class= "govuk-visually-hidden ${msg_class.Inner}" id=${id}></div></div>`;

--- a/app/assets/javascripts/services/Transcript.js
+++ b/app/assets/javascripts/services/Transcript.js
@@ -22,6 +22,9 @@ export default class Transcript {
     }
 
     addOpenerScript(msg) {
+        if(document.getElementsByClassName("cui-technical-error")) {
+            document.getElementsByClassName("cui-technical-error").style.display = "none";
+        }
         this._appendMessage(msg, this.classes.Opener, this.automatedMsgPrefix, false);
     }
 


### PR DESCRIPTION
# DEP-2525: Hide error div when automated msg gets generated

## Checklist PR Raiser
 - [x]  I've ensured code coverage has not decreased
 - [x]  I've dealt with any new compilation warnings
 - [x]  I've ensured the team's coding standards have been met (TBC)?
 - [ ]  If relevant, I've created corresponding app-config-XXX changes?
 - [ ]  If I've created new test data, I've ensured there is no real person's data (see https://confluence.tools.tax.service.gov.uk/display/CD/Test+Data+in+the+Open) 
 - [ ]  I've considered the impact my changes have on the UI/Journey tests (please do not break them)
-  [ ]  If relevant, I've added links to associated PRs

## Checklist PR Reviewer
 - [ ]  I've checked to ensure all relevant unit tests have been written
 - [ ]  I've checked to ensure the team's coding standards have been met
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  If I merge I will ensure I use squash and merge