### PR TITLE
DEP-2757 : Save openerscript timestamp to localstorage

### DIFF
--- a/app/assets/javascripts/services/Transcript.js
+++ b/app/assets/javascripts/services/Transcript.js
@@ -22,8 +22,16 @@ export default class Transcript {
     }
 
     addOpenerScript(msg) {
-        let msgTimestamp = new Date().getTime();
-        this._appendMessage(msg, msgTimestamp, this.classes.Opener, this.automatedMsgPrefix, false, false);
+
+        let openerScriptTimestamp = new Date().getTime();
+
+        if (localStorage.getItem("openerScriptTimestamp") == null) {
+            localStorage.setItem("openerScriptTimestamp", openerScriptTimestamp);
+        }
+
+        openerScriptTimestamp = localStorage.getItem("openerScriptTimestamp");
+
+        this._appendMessage(msg, openerScriptTimestamp, this.classes.Opener, this.automatedMsgPrefix, false, false);
     }
 
     addSkipToBottomLink() {


### PR DESCRIPTION
# DEP-(StoryNumberHere)

## Checklist PR Raiser
 - [x]  I've ensured code coverage has not decreased
 - [x]  I've dealt with any new compilation warnings
 - [x]  I've ensured the team's coding standards have been met (TBC)?
 - [ ]  If relevant, I've created corresponding app-config-XXX changes?
 - [ ]  If I've created new test data, I've ensured there is no real person's data (see https://confluence.tools.tax.service.gov.uk/display/CD/Test+Data+in+the+Open) 
 - [x]  I've considered the impact my changes have on the UI/Journey tests (please do not break them)
-  [ ]  If relevant, I've added links to associated PRs

## Checklist PR Reviewer
 - [x]  I've checked to ensure all relevant unit tests have been written
 - [x]  I've checked to ensure the team's coding standards have been met
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  If I merge I will ensure I use squash and merge