### PR TITLE
DEP-2847 scss added to avoid page breaks for message headings & times…

### DIFF
--- a/app/assets/stylesheets/transcript-agent.scss
+++ b/app/assets/stylesheets/transcript-agent.scss
@@ -65,3 +65,7 @@
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }
+
+.timestamp-outer{
+  page-break-inside: avoid;
+}

--- a/app/assets/stylesheets/transcript-customer.scss
+++ b/app/assets/stylesheets/transcript-customer.scss
@@ -37,3 +37,7 @@
     border: 0.9rem solid;
     border-color: white white transparent transparent;
 }
+
+.timestamp-outer{
+  page-break-inside: avoid;
+}


### PR DESCRIPTION
…tamps

# DEP-2847

## Checklist PR Raiser
 - [ ]  I've ensured code coverage has not decreased
 - [ ]  I've dealt with any new compilation warnings
 - [ ]  I've ensured the team's coding standards have been met (TBC)?
 - [ ]  If relevant, I've created corresponding app-config-XXX changes?
 - [ ]  If I've created new test data, I've ensured there is no real person's data (see https://confluence.tools.tax.service.gov.uk/display/CD/Test+Data+in+the+Open) 
 - [ ]  I've considered the impact my changes have on the UI/Journey tests (please do not break them)
-  [ ]  If relevant, I've added links to associated PRs

## Checklist PR Reviewer
 - [ ]  I've checked to ensure all relevant unit tests have been written
 - [ ]  I've checked to ensure the team's coding standards have been met
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  If I merge I will ensure I use squash and merge