### PR TITLE
DEP-6534 moved displayState check to anchored scenario only + readded…

### DIFF
--- a/app/assets/javascripts/chat-ui.js
+++ b/app/assets/javascripts/chat-ui.js
@@ -51,10 +51,12 @@ export function hookWindow(w, commonChatController, reactiveChatController, proa
     w.nuanceReactive_HMRC_CIAPI_Anchored_1 = safeHandler(
         function nuanceReactive_HMRC_CIAPI_Anchored_1(c2cObj) {  
             c2cObj.c2c = event.c2c
-            if (document.getElementById("tc-nuance-chat-container")) {
-                reactiveChatController.addC2CButton(c2cObj, "tc-nuance-chat-container", "anchored");
-            } else {
-                reactiveChatController.addC2CButton(c2cObj, "HMRC_CIAPI_Anchored_1", "anchored");
+            if (c2cObj.displayState == "ready") {
+                if (document.getElementById("tc-nuance-chat-container")) {
+                    reactiveChatController.addC2CButton(c2cObj, "tc-nuance-chat-container", "anchored");
+                } else {
+                    reactiveChatController.addC2CButton(c2cObj, "HMRC_CIAPI_Anchored_1", "anchored");
+                }
             }
         }
     );

--- a/app/assets/javascripts/controllers/ReactiveChatController.ts
+++ b/app/assets/javascripts/controllers/ReactiveChatController.ts
@@ -34,13 +34,11 @@ export default class ReactiveChatController {
     }
 
     addC2CButton(c2cObj: ClickToChatObjectInterface, divID: string, buttonClass: string): void {
-        if (c2cObj.displayState == "ready") {
-            this.c2cButtons.addButton(
-                c2cObj,
-                new ClickToChatButton(document.getElementById(divID), buttonClass),
-                divID
-            );
-        }
+        this.c2cButtons.addButton(
+            c2cObj,
+            new ClickToChatButton(document.getElementById(divID), buttonClass),
+            divID
+        );
     }
 
     _onC2CButtonClicked(c2cIdx: any): void {

--- a/app/assets/javascripts/controllers/ReactiveChatController.ts
+++ b/app/assets/javascripts/controllers/ReactiveChatController.ts
@@ -40,7 +40,6 @@ export default class ReactiveChatController {
                 new ClickToChatButton(document.getElementById(divID), buttonClass),
                 divID
             );
-        }
     }
 
     _onC2CButtonClicked(c2cIdx: any): void {

--- a/app/assets/javascripts/controllers/ReactiveChatController.ts
+++ b/app/assets/javascripts/controllers/ReactiveChatController.ts
@@ -40,6 +40,7 @@ export default class ReactiveChatController {
                 new ClickToChatButton(document.getElementById(divID), buttonClass),
                 divID
             );
+        }
     }
 
     _onC2CButtonClicked(c2cIdx: any): void {

--- a/app/assets/javascripts/services/ChatStates.js
+++ b/app/assets/javascripts/services/ChatStates.js
@@ -257,13 +257,13 @@ export class EngagedState {
                 transcript.addSystemMsg({msg: (msg["display.text"] || messages.adviserExitedChat)}, msg.messageTimestamp);
                 break;
             case MessageType.Chat_CommunicationQueue:
-                transcript.addSystemMsg({msg: msg.messageText}, msg.messageTimestamp);
+                transcript.addSystemMsg({msg: (msg.messageText || messages.agentBusy)}, msg.messageTimestamp);
                 break;
             case MessageType.Chat_NeedWait:
-                transcript.addSystemMsg({msg: msg.messageText}, msg.messageTimestamp);
+                transcript.addSystemMsg({msg: (msg.messageText || messages.queue1 + msg["queueDepth"] + messages.queue2)}, msg.messageTimestamp);
                 break;
             case MessageType.Chat_Denied:
-                transcript.addSystemMsg({msg: msg["thank_you_image_label"]}, msg.messageTimestamp);
+                transcript.addSystemMsg({msg: (msg["thank_you_image_label"] || messages.adviserUnavailable)}, msg.messageTimestamp);
                 break;
             case MessageType.ChatRoom_MemberLost:
                 this._chatRoomMemberLost(msg, transcript);

--- a/app/assets/javascripts/utils/Messages.ts
+++ b/app/assets/javascripts/utils/Messages.ts
@@ -11,9 +11,14 @@ interface messageTypes {
     automatedMsgPrefix: string
     adviserExitedChat: string
     agentLeftChat: string
+    agentBusy: string
+    queue1: string
+    queue2: string
+    adviserUnavailable: string
 }
 
 const contactLink: string = "<a href='https://www.gov.uk/contact'>Contact us</a> "
+const contactHMRCLink: string = "<a href='https://www.gov.uk/contact-hmrc' target=‘_blank’> other ways to contact HMRC</a>"
 
 export const messages: messageTypes = {
     //PopupContainerHtml.js / EmbeddedContainerHtml
@@ -33,4 +38,9 @@ export const messages: messageTypes = {
     //ChatStates
     adviserExitedChat: "Adviser exited chat",
     agentLeftChat: "Agent Left Chat.",
+    agentBusy: "All of our agents are currently busy. Please wait and an agent will be with you shortly",
+    queue1: "Thank you for your patience, the next available adviser will be with you shortly. You are ",
+    queue2: " in the queue",
+    adviserUnavailable: `I'm sorry, there are no advisers available right now. You can see ${contactHMRCLink}`
+
 };

--- a/test/uk/gov/hmrc/digitalengagementplatformskin/javascripts/controllers/ReactiveChatController.spec.js
+++ b/test/uk/gov/hmrc/digitalengagementplatformskin/javascripts/controllers/ReactiveChatController.spec.js
@@ -58,19 +58,6 @@ describe("ReactiveChatController", () => {
         expect(ClickToChatButton).toBeCalledTimes(1);
     });
 
-    it("addC2CButton does not create a new ClickToChatButton when displayState is busy", () => {
-        const reactiveChatController = new ReactiveChatController();
-        const c2cObj = {displayState: "busy"};
-        const divId = "div-id";
-        const buttonClass = "button-class";
-
-        let addC2CButtonSpy = jest.spyOn(reactiveChatController, 'addC2CButton');
-        reactiveChatController.addC2CButton(c2cObj, divId, buttonClass);
-
-        expect(addC2CButtonSpy).toHaveBeenCalledTimes(1);
-        expect(ClickToChatButton).toBeCalledTimes(0);
-    });
-
     it("attaches a callback function to the SDK onC2CClicked method", () => {
 
         const reactiveChatController = new ReactiveChatController();


### PR DESCRIPTION
… default messages

# DEP-6534

## Checklist PR Raiser
 - [ ]  I've ensured code coverage has not decreased
 - [ ]  I've dealt with any new compilation warnings
 - [ ]  I've ensured the team's coding standards have been met (TBC)?
 - [ ]  If relevant, I've created corresponding app-config-XXX changes?
 - [ ]  If I've created new test data, I've ensured there is no real person's data (see https://confluence.tools.tax.service.gov.uk/display/CD/Test+Data+in+the+Open) 
 - [ ]  I've considered the impact my changes have on the UI/Journey tests (please do not break them)
-  [ ]  If relevant, I've added links to associated PRs

## Checklist PR Reviewer
 - [ ]  I've checked to ensure all relevant unit tests have been written
 - [ ]  I've checked to ensure the team's coding standards have been met
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  If I merge I will ensure I use squash and merge