### PR TITLE
DEP-7196 adding isOnDepFrontendService to condition 

### DIFF
--- a/app/assets/javascripts/controllers/CommonChatController.ts
+++ b/app/assets/javascripts/controllers/CommonChatController.ts
@@ -151,6 +151,10 @@ export default class CommonChatController {
         return ivrWebchatElement.length > 0
     }
 
+    isOnDepFrontendService(): boolean {
+        return this.isIVRWebchatOnly() || document.URL.includes("/ask-hmrc")
+    }
+
     _launchChat(obj: { type: string; state?: StateType }): void {
         if (this.container) {
             return;
@@ -211,7 +215,7 @@ export default class CommonChatController {
 
                 let dav3Skin: HTMLElement | null = document.getElementById("ciapiSkin");
 
-                if (dav3Skin) {
+                if (dav3Skin && this.isOnDepFrontendService()) {
                     this.updateDav3DeskproRefererUrls();
                 }
 


### PR DESCRIPTION
PR to ensure that the '-dav3' gets appended to the 'deskproReferrerUrl' only if the chat is on the digital-engagement-platform-frontend service. There were console errors appearing when appending '-dav3' for the EHL/AOSS service as it couldn't retrieve these hrefs on the page https://github.com/hmrc/digital-engagement-platform-skin/blob/main/app/assets/javascripts/controllers/CommonChatController.ts#L107. So, to fix these errors, only appending '-dav3' if it's on the DEP-frontend service.


# DEP-(StoryNumberHere)

## Checklist PR Raiser
 - [ ]  I've ensured code coverage has not decreased
 - [ ]  I've dealt with any new compilation warnings
 - [ ]  I've ensured the team's coding standards have been met (TBC)?
 - [ ]  If relevant, I've created corresponding app-config-XXX changes?
 - [ ]  If I've created new test data, I've ensured there is no real person's data (see https://confluence.tools.tax.service.gov.uk/display/CD/Test+Data+in+the+Open) 
 - [ ]  I've considered the impact my changes have on the UI/Journey tests (please do not break them)
-  [ ]  If relevant, I've added links to associated PRs

## Checklist PR Reviewer
 - [ ]  I've checked to ensure all relevant unit tests have been written
 - [ ]  I've checked to ensure the team's coding standards have been met
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  If I merge I will ensure I use squash and merge